### PR TITLE
Replace Claude Haiku 4.5 with Groq Llama 3.3 70B for polishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # paply – Voice Transcription für Mac
 
-Voice → Groq Whisper Large V3 → Claude Haiku 4.5 polish. Mac-Utility Look, PWA-ready, Dark/Light.
+Voice → Groq Whisper Large V3 → Groq Llama 3.3 polish. Mac-Utility Look, PWA-ready, Dark/Light.
 
 ---
 
@@ -84,7 +84,6 @@ Für die Web-Version brauchst du API-Keys:
 1. Erstelle `.env.local` im Hauptordner:
 ```
 GROQ_API_KEY=...
-ANTHROPIC_API_KEY=...
 ```
 
 2. Starte den Dev-Server:
@@ -100,7 +99,7 @@ npm run dev
 ## Features
 
 - **Live-Transkription** – MediaRecorder → Chunk-HTTP-POST → Groq Whisper Large V3
-- **AI Polish** – Claude Haiku 4.5 mit Tone (Code/Casual/Formal) + FormatHint (Code Block/Bullets)
+- **AI Polish** – Groq Llama 3.3 mit Tone (Code/Casual/Formal) + FormatHint (Code Block/Bullets)
 - **Cmd+K Palette** – Code Block, Bullets, Formal, Start/Stop Recording, Polish
 - **Copy + Toast** – „Perfekt für Cursor Agent!", Dark/Light Toggle, DE/EN Toggle
 - **PWA manifest** – start_url `/dashboard`, mobile-first Layout

--- a/electron-menubar/README.md
+++ b/electron-menubar/README.md
@@ -1,6 +1,6 @@
 # paply Menubar App
 
-Eigenständige macOS/Windows Menüleisten-App für Sprachtranskription mit Groq Whisper und optional Claude Haiku Polishing.
+Eigenständige macOS/Windows Menüleisten-App für Sprachtranskription mit Groq Whisper und optional Groq Llama Polishing.
 
 ## Features
 
@@ -193,4 +193,4 @@ Bei einem verfügbaren Update wird das Update automatisch heruntergeladen und na
 - electron-updater für Auto-Updates
 - auto-launch für Autostart-Funktion
 - Groq Whisper Large V3 Turbo für Transkription
-- Claude Haiku 4.5 für optionales Polishing
+- Groq Llama 3.3 für optionales Polishing

--- a/electron-menubar/package.json
+++ b/electron-menubar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "paply-menubar",
   "version": "1.5.1",
-  "description": "Menüleisten-App für Sprachtranskription mit Groq Whisper und optional Claude Haiku Polishing",
+  "description": "Menüleisten-App für Sprachtranskription mit Groq Whisper und optional Groq Llama Polishing",
   "main": "electron-main.js",
   "scripts": {
     "dev": "npm run vite:build && electron .",

--- a/electron-menubar/src/apps/dashboard/Dashboard.tsx
+++ b/electron-menubar/src/apps/dashboard/Dashboard.tsx
@@ -1773,7 +1773,6 @@ function SettingsView({
   onSettingChange: (key: keyof SettingsType, value: boolean | string) => void;
 }) {
   const [groqKey, setGroqKey] = useState('');
-  const [haikuKey, setHaikuKey] = useState('');
   const [shortcutInput, setShortcutInput] = useState('');
   const [isRecording, setIsRecording] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -1781,7 +1780,6 @@ function SettingsView({
   useEffect(() => {
     if (settings) {
       setGroqKey(settings.groqApiKey ? '••••••••••••••••' : '');
-      setHaikuKey(settings.haikuApiKey ? '••••••••••••••••' : '');
       setShortcutInput(settings.shortcut || '');
     }
   }, [settings]);
@@ -1808,9 +1806,6 @@ function SettingsView({
     // Save API keys if changed
     if (groqKey && !groqKey.includes('•')) {
       await onSettingChange('groqApiKey', groqKey);
-    }
-    if (haikuKey && !haikuKey.includes('•')) {
-      await onSettingChange('haikuApiKey', haikuKey);
     }
     if (shortcutInput && shortcutInput !== settings?.shortcut) {
       await onSettingChange('shortcut', shortcutInput);
@@ -1841,17 +1836,6 @@ function SettingsView({
               placeholder="gsk_..."
             />
           </div>
-          <div>
-            <Label className="text-xs text-muted-foreground mb-2 block">
-              Anthropic API Key (optional, für Polish)
-            </Label>
-            <Input
-              type="password"
-              value={haikuKey}
-              onChange={(e) => setHaikuKey(e.target.value)}
-              placeholder="sk-ant-..."
-            />
-          </div>
         </CardContent>
       </Card>
 
@@ -1874,7 +1858,7 @@ function SettingsView({
           <div className="flex items-center justify-between">
             <div>
               <Label>Polish aktivieren</Label>
-              <p className="text-xs text-muted-foreground">Mit Claude Haiku optimieren</p>
+              <p className="text-xs text-muted-foreground">Mit Groq Llama optimieren</p>
             </div>
             <Switch
               checked={settings.enablePolish}

--- a/electron-menubar/src/apps/settings/SettingsApp.tsx
+++ b/electron-menubar/src/apps/settings/SettingsApp.tsx
@@ -15,9 +15,7 @@ export function SettingsApp() {
   const [settings, setSettings] = useState<Settings | null>(null);
   const [platform, setPlatform] = useState<Platform | null>(null);
   const [showGroqKey, setShowGroqKey] = useState(false);
-  const [showHaikuKey, setShowHaikuKey] = useState(false);
   const [groqKey, setGroqKey] = useState('');
-  const [haikuKey, setHaikuKey] = useState('');
   const [shortcut, setShortcut] = useState('');
   const [isSaving, setIsSaving] = useState(false);
 
@@ -31,7 +29,6 @@ export function SettingsApp() {
         setSettings(settingsData);
         setPlatform(platformData);
         setGroqKey(settingsData.groqApiKey || '');
-        setHaikuKey(settingsData.haikuApiKey || '');
         setShortcut(settingsData.shortcut || '');
       } catch (error) {
         console.error('Failed to load settings:', error);
@@ -102,7 +99,7 @@ export function SettingsApp() {
             <CardHeader>
               <CardTitle className="text-base">Groq API Key</CardTitle>
               <CardDescription>
-                Für Whisper-Transkription. Hol dir einen Key auf{' '}
+                Für Whisper-Transkription & Text-Polishing. Hol dir einen Key auf{' '}
                 <a
                   href="https://console.groq.com/keys"
                   className="text-primary underline"
@@ -141,48 +138,6 @@ export function SettingsApp() {
             </CardContent>
           </Card>
 
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">Anthropic API Key (Optional)</CardTitle>
-              <CardDescription>
-                Für Polish mit Claude Haiku. Hol dir einen Key auf{' '}
-                <a
-                  href="https://console.anthropic.com/"
-                  className="text-primary underline"
-                  target="_blank"
-                  rel="noopener"
-                >
-                  console.anthropic.com
-                </a>
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="flex gap-2">
-                <div className="relative flex-1">
-                  <Input
-                    type={showHaikuKey ? 'text' : 'password'}
-                    value={haikuKey}
-                    onChange={(e) => setHaikuKey(e.target.value)}
-                    placeholder="sk-ant-..."
-                    className="pr-10"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowHaikuKey(!showHaikuKey)}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                  >
-                    {showHaikuKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                  </button>
-                </div>
-                <Button
-                  onClick={() => handleSave('haikuApiKey', haikuKey)}
-                  disabled={isSaving}
-                >
-                  Speichern
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
         </div>
       )}
 
@@ -279,7 +234,7 @@ export function SettingsApp() {
                 <div>
                   <Label>Polish aktivieren</Label>
                   <p className="text-xs text-muted-foreground">
-                    Text mit Claude Haiku optimieren
+                    Text mit Groq Llama optimieren
                   </p>
                 </div>
                 <Switch

--- a/electron-menubar/src/types/electron.d.ts
+++ b/electron-menubar/src/types/electron.d.ts
@@ -1,6 +1,5 @@
 export interface Settings {
   groqApiKey: string;
-  haikuApiKey: string;
   enablePolish: boolean;
   shortcut: string;
   autoStart: boolean;
@@ -117,7 +116,7 @@ export interface ElectronAPI {
 
   // Stats
   getStats: () => Promise<Stats>;
-  getOwnerStats: () => Promise<{ tokensGroq: number; tokensAnthropic: number; estimatedCost: number } | null>;
+  getOwnerStats: () => Promise<{ tokensGroq: number; tokensGroqPolish: number; estimatedCost: number } | null>;
   onStatsUpdated: (cb: (stats: Stats) => void) => void;
 
   // Owner Mode

--- a/electron-menubar/src/ui/App.tsx
+++ b/electron-menubar/src/ui/App.tsx
@@ -298,7 +298,7 @@ export default function App() {
           />
           Auto-Paste
         </label>
-        <label className="row small-gap" title="Poliert mit Claude Haiku nach Transkription">
+        <label className="row small-gap" title="Poliert mit Groq Llama nach Transkription">
           <input
             type="checkbox"
             checked={enablePolish}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -201,7 +201,7 @@ export default function DashboardPage() {
       const text = data.text ?? "";
       setPolished(text);
       const latency = Math.round(performance.now() - started);
-      console.debug(`[Claude Haiku 4.5] Latency: ${latency}ms`);
+      console.debug(`[Groq Llama 3.3] Latency: ${latency}ms`);
       toast.success("Polished Prompt bereit");
     } catch (error) {
       console.error(error);
@@ -235,7 +235,7 @@ export default function DashboardPage() {
               <span className="text-sm font-semibold text-foreground">
                 Wispr Flow Clone ✨
               </span>
-              <span className="text-xs text-muted-foreground">Groq Whisper · Claude Haiku 4.5</span>
+              <span className="text-xs text-muted-foreground">Groq Whisper · Groq Llama 3.3</span>
             </div>
           </div>
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,7 +18,7 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   title: "paply - Voice Transcription",
-  description: "Sprachtranskription mit Groq Whisper und Claude Haiku Polish",
+  description: "Sprachtranskription mit Groq Whisper und Groq Llama Polish",
 };
 
 export default function RootLayout({

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -4,7 +4,7 @@ export default function manifest(): MetadataRoute.Manifest {
   return {
     name: "paply",
     short_name: "paply",
-    description: "Sprachtranskription mit Groq Whisper und Claude Haiku Polish",
+    description: "Sprachtranskription mit Groq Whisper und Groq Llama Polish",
     start_url: "/dashboard",
     display: "standalone",
     background_color: "#F5F5F7",


### PR DESCRIPTION
Polishing now uses the same Groq API key as Whisper transcription, eliminating the need for a separate Anthropic API key. This reduces output costs by ~6x and improves latency via Groq's LPU inference.

Changes:
- polishText() now calls Groq chat completions (OpenAI-compatible format)
- Removed haikuApiKey from store defaults, settings UI, and IPC handlers
- Updated cost tracking from Anthropic to Groq Llama pricing
- Removed Anthropic API key section from all settings screens
- Updated all labels, descriptions, and documentation

https://claude.ai/code/session_01BzdbtqFUfxS1kiTvLYscM5