### PR TITLE
v1.6.0: Groq Llama 3.3 Polishing, verbesserte Prompts

### DIFF
--- a/electron-menubar/package.json
+++ b/electron-menubar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paply-menubar",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Menüleisten-App für Sprachtranskription mit Groq Whisper und optional Groq Llama Polishing",
   "main": "electron-main.js",
   "scripts": {


### PR DESCRIPTION
- Polishing von Claude Haiku 4.5 auf Groq Llama 3.3 70B umgestellt
- Nur noch ein API-Key (Groq) für Whisper + Polishing nötig
- Output-Kosten ~6x günstiger, Latenz deutlich besser
- Verbesserte Prompts für alle 3 Modi (Coding, Meeting, Diktat)
- Coding: Umfangreiche Tech-Begriff-Erkennung (Groq, Llama, shadcn, useState, etc.)
- Meeting: Automatisches Stichpunkt-Protokoll mit Action Items
- Diktat: Minimale Eingriffe, nur Grammatik/Rechtschreibung
- Anthropic API-Key komplett entfernt

https://claude.ai/code/session_01BzdbtqFUfxS1kiTvLYscM5