### PR TITLE
Fix CI: Release erstellen auch wenn Windows-Build fehlschlägt

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build-mac:
     runs-on: macos-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -40,7 +40,6 @@ jobs:
         working-directory: electron-menubar
         run: npm run build:universal
         env:
-          # Mac Code Signing (optional)
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -56,7 +55,7 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -76,9 +75,8 @@ jobs:
         working-directory: electron-menubar
         run: npm run build:win
         env:
-          # Windows Code Signing (optional - funktioniert auch ohne)
-          CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+          CSC_LINK: ""
+          CSC_KEY_PASSWORD: ""
 
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4
@@ -89,10 +87,10 @@ jobs:
             electron-menubar/dist/latest.yml
 
   create-release:
-    needs: [build-mac, build-windows]
+    needs: [build-mac]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
-    
+
     steps:
       - name: Download Mac artifacts
         uses: actions/download-artifact@v4
@@ -105,6 +103,7 @@ jobs:
         with:
           name: windows-build
           path: ./windows-build
+        continue-on-error: true
 
       - name: List files
         run: |
@@ -126,5 +125,6 @@ jobs:
             ./mac-build/latest-mac.yml
             ./windows-build/*.exe
             ./windows-build/latest.yml
+          fail_on_unmatched_files: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- create-release braucht nur noch build-mac (nicht build-windows)
- Windows artifacts werden mit continue-on-error heruntergeladen
- Code-Signing für Windows deaktiviert (kein Zertifikat vorhanden)
- fail_on_unmatched_files: false für fehlende Windows-Dateien

https://claude.ai/code/session_01BzdbtqFUfxS1kiTvLYscM5